### PR TITLE
Fix Burning Touch name in settings

### DIFF
--- a/Localization/Settings.json
+++ b/Localization/Settings.json
@@ -17,7 +17,7 @@
   {
     "Key": "MoreCantrips.Settings.BurningTouch",
     "ProcessTemplates": false,
-    "enGB": "Add Cantrip: Firebolt"
+    "enGB": "Add Cantrip: Burning Touch"
   },
   {
     "Key": "MoreCantrips.Settings.BurningTouch.Desc",


### PR DESCRIPTION
Just a quick text fix that I noticed.